### PR TITLE
Improve joomla canonical detection

### DIFF
--- a/joomla/components/com_magebridge/models/bridge/headers.php
+++ b/joomla/components/com_magebridge/models/bridge/headers.php
@@ -202,7 +202,9 @@ class MageBridgeModelBridgeHeaders extends MageBridgeModelBridgeSegment
 		if (MagebridgeModelConfig::load('enable_canonical') == 1) { 
 			if (!empty($headers['items'])) {
 				foreach ($headers['items'] as $item) {
-					if ($item['type'] == 'link_rel' && !empty($item['name'])) $document->addHeadLink($item['name'], 'canonical');
+					if ($item['type'] == 'link_rel' && !empty($item['name'] && stripos($item['params'], 'rel="canonical"') !== false)) {
+						$document->addHeadLink($item['name'], 'canonical');
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- Prevent multiple canonical tags when rel=prev/next is present