### PR TITLE
PHP fatal error undefined isJoomla15() on Logout

### DIFF
--- a/joomla/plugins/magento/magebridge/magebridge.php
+++ b/joomla/plugins/magento/magebridge/magebridge.php
@@ -90,9 +90,8 @@ class PlgMagentoMageBridge extends JPlugin
 		$options = array('disable_bridge' => true, 'action' => 'core.login.site');
 
 		// Call the Joomla! event "onLogoutUser"
-		$eventName = (MageBridgeHelper::isJoomla15()) ? 'onLogoutUser' : 'onUserLogout';
 		JPluginHelper::importPlugin('user');
-		JFactory::getApplication()->triggerEvent($eventName, array($customer, $options));
+		JFactory::getApplication()->triggerEvent('onUserLogout', array($customer, $options));
 
 		return true;
 	}


### PR DESCRIPTION
I have removed this row
$eventName = (MageBridgeHelper::isJoomla15()) ? 'onLogoutUser' : 'onUserLogout';

and harcoded 'onUserLogout' in

JFactory::getApplication()->triggerEvent('onUserLogout', array($customer, $options));

This solve the problem of a 500 error when we do logout

Lot of thanks to @marcofabbri-a1 who have found the bug!